### PR TITLE
fix: allow for attribution to remain hidden

### DIFF
--- a/dash_leaflet_basemaps/__init__.py
+++ b/dash_leaflet_basemaps/__init__.py
@@ -11,11 +11,12 @@ __email__ = "pierrick.rambaud49@gmail.com"
 class BasemapLayer(dl.TileLayer):
     """A class to represent a basemap layer."""
 
-    def __init__(self, name: str, **kwargs):
+    def __init__(self, name: str, show_attribution: bool = True, **kwargs):
         """Initialize the class.
 
         Args:
             name: The name of the basemap.
+            show_attribution: decide if the attribution of the newly added layer should be displayed in leaflet attributions. Must be done in agreement with the licence of each individual layer. Default is ``True``.
             kwargs: any keyword arguments from dash-leaflet TileLayer class knowing that ``url``, ``id`` and ``attribution`` will be ignored.
         """
         # check if the name exists
@@ -27,6 +28,10 @@ class BasemapLayer(dl.TileLayer):
         # get the basemap
         kwargs["url"] = basemap_tiles[name].url
         kwargs["id"] = basemap_tiles[name].id
-        kwargs["attribution"] = basemap_tiles[name].attribution
         kwargs["maxZoom"] = kwargs.get("maxZoom", basemap_tiles[name].max_zoom)
+
+        # add the atribution if requested
+        if show_attribution is True:
+            kwargs["attribution"] = basemap_tiles[name].attribution
+
         super().__init__(**kwargs)


### PR DESCRIPTION
This a dodgy modification required for a commercial use of certain layers. I remain convinced people should always give credits to the amazing tools they are using but apparently we are not so many on this boat. 